### PR TITLE
Use action for tour items

### DIFF
--- a/src/Tour.svelte
+++ b/src/Tour.svelte
@@ -19,8 +19,8 @@
     currentStep++;
   }
 
-  function getScrimStyle(step) {
-    const boundingRect = step.getBoundingClientRect();
+  function getScrimStyle(item) {
+    const boundingRect = item.element.getBoundingClientRect();
     const left = boundingRect.left;
     const right = left + boundingRect.width;
     const top = boundingRect.top;
@@ -42,9 +42,9 @@
     `;
   }
 
-	function getTooltipStyle(step) {
+  function getTooltipStyle(item) {
     const TOOLTIP_WIDTH = 300;
-    const boundingRect = step.getBoundingClientRect();
+    const boundingRect = item.element.getBoundingClientRect();
     const itemHorizontalCenter = boundingRect.left + boundingRect.width / 2;
     let tooltipLeft = itemHorizontalCenter - (TOOLTIP_WIDTH / 2);
     if (tooltipLeft < 0) tooltipLeft = 0;
@@ -59,7 +59,7 @@
     <svelte:component
       this={TourTip}
       {atEnd}
-      message={items[currentStep].getAttribute('data-tour')}
+      message={items[currentStep].parameters.message}
       {onClickNext}
     />
   </div>

--- a/src/Tour.svelte
+++ b/src/Tour.svelte
@@ -56,11 +56,12 @@
 {#if active && items && items.length}
   <div class="scrim" style={getScrimStyle(items[currentStep])}></div>
   <div class="tooltip" style={getTooltipStyle(items[currentStep])}>
-    <TourTip
+    <svelte:component
+      this={TourTip}
       {atEnd}
       message={items[currentStep].getAttribute('data-tour')}
       {onClickNext}
-    ></TourTip>
+    />
   </div>
 {/if}
 

--- a/src/TourItem.svelte
+++ b/src/TourItem.svelte
@@ -3,10 +3,12 @@
   import { register, unregister } from './index';
 
   export let message;
+  export let sequence = 0;
+
   let element;
 
   onMount(() => {
-    register(element);
+    register(element, { message, sequence });
   });
 
   onDestroy(() => {
@@ -14,6 +16,6 @@
   });
 </script>
 
-<div bind:this={element} data-tour={message}>
   <slot></slot>
+<div bind:this={element}>
 </div>

--- a/src/index.js
+++ b/src/index.js
@@ -8,19 +8,26 @@ const tourStore = writable({
 export { default as Tour } from './Tour.svelte';
 export { default as TourItem } from './TourItem.svelte';
 export { default as TourTip } from './TourTip.svelte';
+export { tour } from './tour.js';
 
-export function register(el) {
+export function register(el, parameters) {
   tourStore.update(store => ({
     ...store,
-    items: [...store.items, el]
+    items: [...store.items.filter(item => item.element !== el), { element: el, parameters: parameters }]
   }));
 };
 
 export function run() {
-  tourStore.update(store => ({
-    ...store,
-    active: true
-  }));
+  tourStore.update(store => {
+    
+    const sortedItems = store.items;
+    sortedItems.sort((a,b) => (a.parameters.sequence > b.parameters.sequence) ? 1 : ((b.parameters.sequence > a.parameters.sequence) ? -1 : 0))
+    return {
+      ...store,
+      items: sortedItems,
+      active: true
+    };
+  });
 };
 
 export function stop() {
@@ -33,7 +40,7 @@ export function stop() {
 export function unregister(el) {
   tourStore.update(store => ({
     ...store,
-    items: store.items.filter(item => item !== el)
+    items: store.items.filter(item => item.element !== el)
   }));
 }
 

--- a/src/tour.js
+++ b/src/tour.js
@@ -1,0 +1,15 @@
+import { register, unregister } from './index';
+
+export function tour(node, parameters){
+
+  register(node, parameters);
+
+  return {
+    update(newParameters){
+      register(node, newParameters);
+    }, 
+    destroy(){
+      unregister(node);
+    }
+  };
+}


### PR DESCRIPTION
Since using a `<TourItem>` block around an element adds a `<div>` that couldn't easily be styled to not break my layout, I had to add the option for using an action to add tour items.

This pull request adds a "tour" action, so that you can do this:

```
import { Tour, TourTip, tour, run } from 'svelte-tour';

<main>
    <span use:tour={{message: "A tour item"}}>Blah, blah</span>
</main>
```

Instead of:

```
<TourItem message={"A tour item"}>
    <span>Blah, blah</span>
</TourItem>
```

(Or in addition to, actually -- I didn't remove the TourItem component.)

Also, I added a sequence to the tour parameters so that I can control the sequence of the messages in the tour:
`
<span use:tour={{message: "A tour item", sequence: 3}}>Blah, blah</span>`

This change makes the "data-tour" attribute unneccessary, so I removed it. Items in the store are now saved together with their parameters instead.

Use some of it, all of it or ignore it, no hard feelings any way. :)